### PR TITLE
Update 99-one-step-install-sonarqube.sh

### DIFF
--- a/setup/sonarqube/99-one-step-install-sonarqube.sh
+++ b/setup/sonarqube/99-one-step-install-sonarqube.sh
@@ -23,7 +23,7 @@ fi
 
 set -e
 
-git clone https://github.com/SonarSource/helm-chart-sonarqube.git
+git clone https://github.com/SonarSource/helm-chart-sonarqube.git --depth 1 -b sonarqube-lts-1.0.19
 cd helm-chart-sonarqube/charts/sonarqube
 helm dependency update
 kubectl create namespace sonarqube
@@ -31,7 +31,7 @@ kubectl create namespace sonarqube
 kubectl taint nodes devsecops-w1 sonarqube=true:NoSchedule --overwrite=true
 kubectl label node devsecops-w1  sonarqube=true --overwrite=true
 
-helm install --version 1.0.19 -f ~/devsecops/sonarqube/sonarqube-values.yaml -n sonarqube sonarqube ./
+helm install -f ~/devsecops/sonarqube/sonarqube-values.yaml -n sonarqube sonarqube ./
 
 echo "Your Sonarqube instance is provisioning...."
 while [ `kubectl get sts -n sonarqube | grep 1/1 | wc -l` -ne 2 ]


### PR DESCRIPTION
specified a version (v1.0.19) by tag sonarqube-lts-1.0.19, to avoid changes caused by latest version.
also removed the --version parameter in helm install command as it seems not work in cloned local git repository.